### PR TITLE
Fix video API URL

### DIFF
--- a/src/services/pexels-service.ts
+++ b/src/services/pexels-service.ts
@@ -164,7 +164,7 @@ export class PexelsService {
 
     // Determine the base URL based on the endpoint
     const isVideoEndpoint = endpoint.startsWith('/videos');
-    const url = `${this.baseUrl}${isVideoEndpoint ? '/videos' : '/v1'}${endpoint}${
+    const url = `${this.baseUrl}${isVideoEndpoint ? '' : '/v1'}${endpoint}${
       queryParams.toString() ? '?' + queryParams.toString() : ''
     }`;
 


### PR DESCRIPTION
It currently is incorrectly resulting in urls like `/videos/videos/whatever` instead of `/videos/whatever`.